### PR TITLE
Recorder becomes unusable after Stop()

### DIFF
--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -548,20 +548,14 @@ HRESULT internal_recorder::BeginRecording(std::wstring path, IStream *stream) {
 		}
 #endif
 		if (!m_IsDestructed) {
-			if (SUCCEEDED(hr)) {
-				if (RecordingStatusChangedCallback != NULL)
-					RecordingStatusChangedCallback(STATUS_IDLE);
-				RecordingStatusChangedCallback = NULL;
-
+			if (RecordingStatusChangedCallback != NULL)
+				RecordingStatusChangedCallback(STATUS_IDLE);
+			if (SUCCEEDED(hr)) {				
 				if (RecordingCompleteCallback != NULL)
-					RecordingCompleteCallback(m_OutputFullPath, m_FrameDelays);
-				RecordingCompleteCallback = NULL;
-				RecordingStatusChangedCallback = NULL;
-			}
+					RecordingCompleteCallback(m_OutputFullPath, m_FrameDelays);							}
 			else {
-				if (RecordingStatusChangedCallback != NULL)
-					RecordingStatusChangedCallback(STATUS_IDLE);
 				RecordingStatusChangedCallback = NULL;
+				RecordingCompleteCallback = NULL;
 				if (RecordingFailedCallback != NULL) {
 
 					std::wstring errMsg;


### PR DESCRIPTION
After `Stop()` has been called, all event handlers of `internal_recorder` are unregistered. The Recorder cannot be reused to start a recording using `Record(string path)`

In this PR the event handlers are only unregistered in case `m_SinkWriter->Finalize()` fails. But I am not sure why `Stop() `should unregister the events at all.