### PR TITLE
fix: In the GetOutputForDeviceName method not process enumration

### DIFF
--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -831,7 +831,7 @@ HRESULT internal_recorder::GetOutputForDeviceName(std::wstring deviceName, IDXGI
 				SafeRelease(&pOutput);
 				i++;
 			}
-			if (ppOutput) {
+			if (*ppOutput) {
 				break;
 			}
 		}


### PR DESCRIPTION
fix: In the GetOutputForDeviceName method, the adapter was not processed repeatedly, because that the adapter was always break after processing the first adapter.

("ppOutput" is always not null.)