### PR TITLE
Reset cancellation token

### DIFF
--- a/ScreenRecorderLib/WWMFResampler.cpp
+++ b/ScreenRecorderLib/WWMFResampler.cpp
@@ -93,11 +93,6 @@ CreateResamplerMFT(
 HRESULT
 WWMFResampler::Initialize(const WWMFPcmFormat &inputFormat, const WWMFPcmFormat &outputFormat, int halfFilterLength)
 {
-	LOG("Resampler (bits): %u -> %u", inputFormat.bits, outputFormat.bits);
-	LOG("Resampler (channels): %u -> %u", inputFormat.nChannels, outputFormat.nChannels);
-	LOG("Resampler (sampleFormat): %i -> %i", inputFormat.sampleFormat, outputFormat.sampleFormat);
-	LOG("Resampler (sampleRate): %u -> %u", inputFormat.sampleRate, outputFormat.sampleRate);
-	LOG("Resampler (validBitsPerSample): %u -> %u", inputFormat.validBitsPerSample, outputFormat.validBitsPerSample);
 	m_inputFormat = inputFormat;
 	m_outputFormat = outputFormat;
 	assert(m_pTransform == NULL);

--- a/ScreenRecorderLib/WWMFResampler.cpp
+++ b/ScreenRecorderLib/WWMFResampler.cpp
@@ -93,6 +93,11 @@ CreateResamplerMFT(
 HRESULT
 WWMFResampler::Initialize(const WWMFPcmFormat &inputFormat, const WWMFPcmFormat &outputFormat, int halfFilterLength)
 {
+	LOG("Resampler (bits): %u -> %u", inputFormat.bits, outputFormat.bits);
+	LOG("Resampler (channels): %u -> %u", inputFormat.nChannels, outputFormat.nChannels);
+	LOG("Resampler (sampleFormat): %i -> %i", inputFormat.sampleFormat, outputFormat.sampleFormat);
+	LOG("Resampler (sampleRate): %u -> %u", inputFormat.sampleRate, outputFormat.sampleRate);
+	LOG("Resampler (validBitsPerSample): %u -> %u", inputFormat.validBitsPerSample, outputFormat.validBitsPerSample);
 	m_inputFormat = inputFormat;
 	m_outputFormat = outputFormat;
 	assert(m_pTransform == NULL);

--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -769,7 +769,8 @@ HRESULT internal_recorder::BeginRecording(std::wstring path, IStream *stream) {
 		}
 		LOG("Exiting recording task");
 		return hr;
-	}).then([this, token](HRESULT hr) {
+	})
+	.then([this, token](HRESULT hr) {
 		m_IsRecording = false;
 
 		if (!m_IsDestructed) {
@@ -805,7 +806,8 @@ HRESULT internal_recorder::BeginRecording(std::wstring path, IStream *stream) {
 #endif
 		}
 		return hr;
-	}).then([this](concurrency::task<HRESULT> t)
+	})
+	.then([this](concurrency::task<HRESULT> t)
 	{
 		std::wstring errMsg = L"";
 		bool success = false;

--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -61,7 +61,7 @@ struct internal_recorder::TaskWrapper {
 };
 
 
-internal_recorder::internal_recorder() :m_TaskWrapperImpl(new TaskWrapper())
+internal_recorder::internal_recorder()
 {
 	m_IsDestructed = false;
 }
@@ -325,7 +325,7 @@ HRESULT internal_recorder::BeginRecording(std::wstring path, IStream *stream) {
 	if (!path.empty()) {
 		RETURN_ON_BAD_HR(ConfigureOutputDir(path));
 	}
-
+	m_TaskWrapperImpl = std::make_unique<TaskWrapper>();
 	cancellation_token token = m_TaskWrapperImpl->m_RecordTaskCts.get_token();
 
 	if (m_IsMouseClicksDetected) {

--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -36,7 +36,7 @@ using namespace std::chrono;
 using namespace concurrency;
 using namespace DirectX;
 
-UINT g_LastMouseClickDurationRemaining;
+UINT64 g_LastMouseClickDurationRemaining;
 UINT g_MouseClickDetectionDurationMillis = 50;
 UINT g_LastMouseClickButton;
 // Driver types supported
@@ -616,8 +616,7 @@ HRESULT internal_recorder::BeginRecording(std::wstring path, IStream *stream) {
 					if (hr == S_OK || pPreviousFrameCopy == nullptr || durationSinceLastFrame100Nanos < videoFrameDuration100Nanos) {
 						UINT32 delay = 1;
 						if (durationSinceLastFrame100Nanos < videoFrameDuration100Nanos) {
-							double d = (videoFrameDuration100Nanos - durationSinceLastFrame100Nanos) / 10 / 1000;
-							delay = round(d);
+							delay = static_cast<UINT32>((videoFrameDuration100Nanos - durationSinceLastFrame100Nanos) / 10 / 1000);
 						}
 
 						wait(delay);
@@ -683,7 +682,7 @@ HRESULT internal_recorder::BeginRecording(std::wstring path, IStream *stream) {
 						{
 							hr = pMousePointer->DrawMouseClick(&PtrInfo, pFrameCopy, m_MouseClickDetectionRMBColor, m_MouseClickDetectionRadius, screenRotation);
 						}
-						UINT millis = max(durationSinceLastFrame100Nanos / 10 / 1000, 0);
+						auto millis = max(durationSinceLastFrame100Nanos / 10 / 1000, 0);
 						g_LastMouseClickDurationRemaining = max(g_LastMouseClickDurationRemaining - millis, 0);
 						LOG("Drawing mouse click, duration remaining on click is %u ms", g_LastMouseClickDurationRemaining);
 					}
@@ -745,7 +744,7 @@ HRESULT internal_recorder::BeginRecording(std::wstring path, IStream *stream) {
 					lastFrameStartPos += durationSinceLastFrame100Nanos;
 					if (m_IsFixedFramerate)
 					{
-						wait(videoFrameDurationMillis);
+						wait(static_cast<UINT32>(videoFrameDurationMillis));
 					}
 				}
 			}
@@ -1364,8 +1363,8 @@ HRESULT internal_recorder::EnqueueFrame(FrameWriteModel model) {
 		//If the audio pCaptureInstance returns no data, i.e. the source is silent, we need to pad the PCM stream with zeros to give the media sink silence as input.
 		//If we don't, the sink writer will begin throttling video frames because it expects audio samples to be delivered, and think they are delayed.
 		if (m_IsAudioEnabled && model.Audio.size() == 0) {
-			int frameCount = ceil(m_InputAudioSamplesPerSecond * ((double)model.Duration / 10 / 1000 / 1000));
-			UINT32 byteCount = frameCount * (AUDIO_BITS_PER_SAMPLE / 8)*m_AudioChannels;
+			auto frameCount = static_cast<UINT32>(ceil(m_InputAudioSamplesPerSecond * ((double)model.Duration / 10 / 1000 / 1000)));
+			auto byteCount = frameCount * (AUDIO_BITS_PER_SAMPLE / 8)*m_AudioChannels;
 			model.Audio.insert(model.Audio.end(), byteCount, 0);
 			LOG(L"Inserted %zd bytes of silence", model.Audio.size());
 		}
@@ -1408,9 +1407,14 @@ std::string internal_recorder::NowToString()
 {
 	chrono::system_clock::time_point p = chrono::system_clock::now();
 	time_t t = chrono::system_clock::to_time_t(p);
+	struct tm newTime;
+	auto err = localtime_s(&newTime, &t);
 
-	std::stringstream ss;
-	ss << std::put_time(std::localtime(&t), "%Y-%m-%d %X");
+	std::stringstream ss;	
+	if (err)
+		ss << "NEW";
+	else
+		ss << std::put_time(&newTime, "%Y-%m-%d %X");
 	string time = ss.str();
 	std::replace(time.begin(), time.end(), ':', '-');
 	return time;

--- a/ScreenRecorderLib/loopback_capture.cpp
+++ b/ScreenRecorderLib/loopback_capture.cpp
@@ -149,6 +149,11 @@ HRESULT loopback_capture::LoopbackCapture(
 
 	// initialize resampler if sample rate differs from 44.1kHz or 48kHz
 	if (inputFormat.sampleRate != outputFormat.sampleRate) {
+		LOG("Resampler (bits): %u -> %u", inputFormat.bits, outputFormat.bits);
+		LOG("Resampler (channels): %u -> %u", inputFormat.nChannels, outputFormat.nChannels);
+		LOG("Resampler (sampleFormat): %i -> %i", inputFormat.sampleFormat, outputFormat.sampleFormat);
+		LOG("Resampler (sampleRate): %lu -> %lu", inputFormat.sampleRate, outputFormat.sampleRate);
+		LOG("Resampler (validBitsPerSample): %u -> %u", inputFormat.validBitsPerSample, outputFormat.validBitsPerSample);		
 		resampler.Initialize(inputFormat, outputFormat, 60);
 	}
 	else

--- a/ScreenRecorderLib/loopback_capture.cpp
+++ b/ScreenRecorderLib/loopback_capture.cpp
@@ -151,6 +151,10 @@ HRESULT loopback_capture::LoopbackCapture(
 	if (inputFormat.sampleRate != outputFormat.sampleRate) {
 		resampler.Initialize(inputFormat, outputFormat, 60);
 	}
+	else
+	{
+		LOG("No resampling nescessary");
+	}
 
 	// create a periodic waitable timer
 	HANDLE hWakeUp = CreateWaitableTimer(NULL, FALSE, NULL);

--- a/Tests/FunctionTests.cs
+++ b/Tests/FunctionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,34 +12,35 @@ namespace ScreenRecorderLib
         [TestMethod]
         public void RunInTestMethodTest()
         {
-            Stream outStream = new MemoryStream();
-            
-            var rec = ScreenRecorderLib.Recorder.CreateRecorder();
-            
-            bool isError = false;
-            bool isComplete = false;
-            ManualResetEvent resetEvent = new ManualResetEvent(false);
-            rec.OnRecordingComplete += (s, args) =>
+            using (var outStream = new MemoryStream())
             {
-                isComplete = true;
-                resetEvent.Set();
-            };
-            rec.OnRecordingFailed += (s, args) =>
-            {
-                isError = true;
-                resetEvent.Set();
-            };
+                using (var rec = Recorder.CreateRecorder())
+                {
+                    bool isError = false;
+                    bool isComplete = false;
+                    ManualResetEvent resetEvent = new ManualResetEvent(false);
+                    rec.OnRecordingComplete += (s, args) =>
+                    {
+                        isComplete = true;
+                        resetEvent.Set();
+                    };
+                    rec.OnRecordingFailed += (s, args) =>
+                    {
+                        isError = true;
+                        resetEvent.Set();
+                    };
 
-            rec.Record(outStream);
-            Thread.Sleep(3000);
-            rec.Stop();
-            
-            resetEvent.WaitOne(5000);
-            rec.Dispose();
-            Assert.IsNotNull(outStream);
-            Assert.IsFalse(isError);
-            Assert.IsTrue(isComplete);
-            Assert.AreNotEqual(outStream.Length, 0);
+                    rec.Record(outStream);
+                    Thread.Sleep(3000);
+                    rec.Stop();
+                    resetEvent.WaitOne(5000);
+
+                    Assert.IsFalse(isError);
+                    Assert.IsTrue(isComplete);
+                    Assert.AreNotEqual(outStream.Length, 0);
+                }
+            }
+
         }
 
         [TestMethod]
@@ -46,14 +48,52 @@ namespace ScreenRecorderLib
         {
             for (int i = 0; i < 50; i++)
             {
-                Stream outStream = new MemoryStream();
-                RecorderOptions options = new RecorderOptions();
-                options.VideoOptions = new VideoOptions { Framerate = 60, IsFixedFramerate = false };
-                var rec = ScreenRecorderLib.Recorder.CreateRecorder(options);
-                string error = "";
-                bool isError = false;
-                bool isComplete = false;
-                ManualResetEvent resetEvent = new ManualResetEvent(false);
+                using (Stream outStream = new MemoryStream())
+                {
+                    RecorderOptions options = new RecorderOptions();
+                    options.VideoOptions = new VideoOptions { Framerate = 60, IsFixedFramerate = false };
+                    using (var rec = Recorder.CreateRecorder(options))
+                    {
+                        string error = "";
+                        bool isError = false;
+                        bool isComplete = false;
+                        ManualResetEvent resetEvent = new ManualResetEvent(false);
+                        rec.OnRecordingComplete += (s, args) =>
+                        {
+                            isComplete = true;
+                            resetEvent.Set();
+                        };
+                        rec.OnRecordingFailed += (s, args) =>
+                        {
+                            isError = true;
+                            error = args.Error;
+                            resetEvent.Set();
+                        };
+
+                        rec.Record(outStream);
+                        Thread.Sleep(2000);
+                        rec.Stop();
+
+                        Assert.IsTrue(resetEvent.WaitOne(5000), $"[{i}] Recording finalize timed out");
+                        Assert.IsNotNull(outStream, $"[{i}] Outstream is null");
+                        Assert.IsFalse(isError, $"[{i}] Recording error: " + error);
+                        Assert.IsTrue(isComplete, $"[{i}] Recording not complete");
+                        Assert.AreNotEqual(outStream.Length, 0, $"[{i}] Outstream length is 0");
+                    }
+                }
+            }
+        }
+        [TestMethod]
+        public void Run50RecordingsTestWithOneInstance()
+        {
+            string error = "";
+            bool isError = false;
+            bool isComplete = false;
+            AutoResetEvent resetEvent = new AutoResetEvent(false);
+            RecorderOptions options = new RecorderOptions();
+            options.VideoOptions = new VideoOptions { Framerate = 60, IsFixedFramerate = false };
+            using (var rec = Recorder.CreateRecorder(options))
+            {
                 rec.OnRecordingComplete += (s, args) =>
                 {
                     isComplete = true;
@@ -65,58 +105,24 @@ namespace ScreenRecorderLib
                     error = args.Error;
                     resetEvent.Set();
                 };
+                for (int i = 0; i < 50; i++)
+                {
+                    using (var outStream = new MemoryStream())
+                    {
+                        isError = false;
+                        isComplete = false;
+                        rec.Record(outStream);
+                        Thread.Sleep(2000);
+                        rec.Stop();
 
-                rec.Record(outStream);
-                Thread.Sleep(2000);
-                rec.Stop();
-                Assert.IsTrue(resetEvent.WaitOne(5000), "Recording finalize timed out");
-                Assert.IsNotNull(outStream, "Outstream is null");
-                Assert.IsFalse(isError, "Recording error: "+error);
-                Assert.IsTrue(isComplete, "Recording not complete");
-                Assert.AreNotEqual(outStream.Length, 0, "Outstream length is 0");
-                rec.Dispose();
-                rec = null;
-                outStream.Dispose();
+                        Assert.IsTrue(resetEvent.WaitOne(), $"[{i}] Recording finalize timed out");
+                        Assert.IsNotNull(outStream, $"[{i}] Outstream is null");
+                        Assert.IsFalse(isError, $"[{i}] Recording error: " + error);
+                        Assert.IsTrue(isComplete, $"[{i}] Recording not complete");
+                        Assert.AreNotEqual(outStream.Length, 0, $"[{i}] Outstream length is 0");
+                    }
+                }
             }
-        }
-        [TestMethod]
-        public void Run50RecordingsTestWithOneInstance()
-        {
-            string error = "";
-            bool isError = false;
-            bool isComplete = false;
-            AutoResetEvent resetEvent = new AutoResetEvent(false);
-            RecorderOptions options = new RecorderOptions();
-            options.VideoOptions = new VideoOptions { Framerate = 60, IsFixedFramerate=false };
-            var rec = ScreenRecorderLib.Recorder.CreateRecorder(options);
-            rec.OnRecordingComplete += (s, args) =>
-            {
-                isComplete = true;
-                resetEvent.Set();
-            };
-            rec.OnRecordingFailed += (s, args) =>
-            {
-                isError = true;
-                error = args.Error;
-                resetEvent.Set();
-            };
-            for (int i = 0; i < 50; i++)
-            {
-                Stream outStream = new MemoryStream();
-                isError = false;
-                isComplete = false;
-                rec.Record(outStream);
-                Thread.Sleep(2000);
-                rec.Stop();
-                Assert.IsTrue(resetEvent.WaitOne(5000), "Recording finalize timed out");
-                Assert.IsNotNull(outStream, "Outstream is null");
-                Assert.IsFalse(isError, "Recording error: "+error);
-                Assert.IsTrue(isComplete, "Recording not complete");
-                Assert.AreNotEqual(outStream.Length, 0, "Outstream length is 0");
-                outStream.Dispose();
-            }
-            rec.Dispose();
-            rec = null;
         }
     }
 }

--- a/Tests/FunctionTests.cs
+++ b/Tests/FunctionTests.cs
@@ -12,7 +12,9 @@ namespace ScreenRecorderLib
         public void RunInTestMethodTest()
         {
             Stream outStream = new MemoryStream();
+            
             var rec = ScreenRecorderLib.Recorder.CreateRecorder();
+            
             bool isError = false;
             bool isComplete = false;
             ManualResetEvent resetEvent = new ManualResetEvent(false);
@@ -30,7 +32,9 @@ namespace ScreenRecorderLib
             rec.Record(outStream);
             Thread.Sleep(3000);
             rec.Stop();
+            
             resetEvent.WaitOne(5000);
+            rec.Dispose();
             Assert.IsNotNull(outStream);
             Assert.IsFalse(isError);
             Assert.IsTrue(isComplete);


### PR DESCRIPTION
This PR resets the m_TaskWrapperImpl on every BeginRecording(). Now the unit tests die after about 30 iterations instead of dying after the first one. However there is still a memory leak.

Also fixed some compile time warnings.

