### PR TITLE
Adding audio volume mixer

### DIFF
--- a/ScreenRecorderLib/Recorder.cpp
+++ b/ScreenRecorderLib/Recorder.cpp
@@ -65,6 +65,8 @@ void Recorder::SetOptions(RecorderOptions^ options) {
 			if (options->AudioOptions->AudioInputDevice != nullptr) {
 				lRec->SetInputDevice(msclr::interop::marshal_as<std::wstring>(options->AudioOptions->AudioInputDevice));
 			}
+			lRec->SetInputVolume(options->AudioOptions->InputVolume);
+			lRec->SetOutputVolume(options->AudioOptions->OutputVolume);
 		}
 		if (options->MouseOptions) {
 			lRec->SetMousePointerEnabled(options->MouseOptions->IsMousePointerEnabled);
@@ -87,6 +89,22 @@ void Recorder::SetOptions(RecorderOptions^ options) {
 			lRec->SetLogFilePath(msclr::interop::marshal_as<std::wstring>(options->LogFilePath));
 		}
 		lRec->SetLogSeverityLevel((UINT32)options->LogSeverityLevel);
+	}
+}
+
+void Recorder::SetInputVolume(float volume)
+{
+	if(lRec)
+	{
+		lRec->SetInputVolume(volume);
+	}
+}
+
+void Recorder::SetOutputVolume(float volume)
+{
+	if (lRec)
+	{
+		lRec->SetOutputVolume(volume);
 	}
 }
 

--- a/ScreenRecorderLib/Recorder.h
+++ b/ScreenRecorderLib/Recorder.h
@@ -179,6 +179,8 @@ namespace ScreenRecorderLib {
 			IsInputDeviceEnabled = false;
 			Bitrate = AudioBitrate::bitrate_96kbps;
 			Channels = AudioChannels::Stereo;
+			InputVolume = 1.0f;
+			OutputVolume = 1.0f;
 		}
 		property bool IsAudioEnabled;
 		/// <summary>
@@ -199,6 +201,20 @@ namespace ScreenRecorderLib {
 		///Audio input device to capture audio from. Pass null or empty string to select system default.
 		/// </summary>
 		property String^ AudioInputDevice;
+
+		/// <summary>
+		/// Volume if the input stream. Recommended values are between 0 and 1.
+		/// Value of 0 mutes the stream and value of 1 makes it original volume.
+		/// This value can be changed after the recording is started with SetInputVolume() method.
+		/// </summary>
+		property float InputVolume;
+
+		/// <summary>
+		/// Volume if the output stream. Recommended values are between 0 and 1.
+		/// Value of 0 mutes the stream and value of 1 makes it original volume.
+		/// This value can be changed after the recording is started with SetOutputVolume() method.
+		/// </summary>
+		property float OutputVolume;
 	};
 	public ref class MouseOptions {
 	public:
@@ -354,6 +370,8 @@ namespace ScreenRecorderLib {
 		void Resume();
 		void Stop();
 		void SetOptions(RecorderOptions^ options);
+		void SetInputVolume(float volume);
+		void SetOutputVolume(float volume);
 		static Recorder^ CreateRecorder();
 		static Recorder^ CreateRecorder(RecorderOptions^ options);
 		static Dictionary<String^, String^>^ GetSystemAudioDevices(AudioDeviceSource source);

--- a/ScreenRecorderLib/internal_recorder.h
+++ b/ScreenRecorderLib/internal_recorder.h
@@ -77,6 +77,9 @@ public:
 	void SetInputDeviceEnabled(bool value);
 	void SetMousePointerEnabled(bool value);
 	void SetDestRectangle(RECT rect);
+	void SetInputVolume(float volume);
+	void SetOutputVolume(float volume);
+	
 	[[deprecated]]
 	void SetDisplayOutput(UINT32 output);
 	void SetDisplayOutput(std::wstring output);
@@ -161,11 +164,12 @@ private:
 	UINT32 m_MouseClickDetectionRadius = 20;
 	UINT32 m_MouseClickDetectionMode = MOUSE_DETECTION_MODE_POLLING;
 	GUID m_ImageEncoderFormat = GUID_ContainerFormatPng;
-
+	float m_InputVolumeModifier = 1;
+	float m_OutputVolumeModifier = 1;
 	//functions
 	std::string CurrentTimeToFormattedString();
 	std::vector<BYTE> GrabAudioFrame(std::unique_ptr<loopback_capture>& pLoopbackCaptureOutputDevice, std::unique_ptr<loopback_capture>& pLoopbackCaptureInputDevice);
-	std::vector<BYTE> MixAudio(std::vector<BYTE> &first, std::vector<BYTE> &second);
+	std::vector<BYTE> MixAudio(std::vector<BYTE> &first, std::vector<BYTE> &second, float firstVolume, float secondVolume);
 	void SetDebugName(ID3D11DeviceChild* child, const std::string& name);
 	void SetViewPort(ID3D11DeviceContext *deviceContext, UINT Width, UINT Height);
 	std::wstring GetImageExtension();

--- a/TestApp/MainWindow.xaml
+++ b/TestApp/MainWindow.xaml
@@ -373,35 +373,61 @@
                           x:Name="CheckBoxRecordToStream"
                           IsChecked="{Binding ElementName=MainWin,Path=RecordToStream}"
                           Margin="5" />
-                <TextBlock FontSize="72"
-                           Text="00:00:00"
-                           HorizontalAlignment="Center"
-                           x:Name="TimeStampTextBlock" />
-                <TextBlock FontSize="42"
-                           Text="Idle"
-                           HorizontalAlignment="Center"
-                           x:Name="StatusTextBlock" />
-                <TextBlock FontSize="12"
-                           Text=""
-                           Margin="10,0"
-                           TextWrapping="Wrap"
-                           HorizontalAlignment="Center"
-                           x:Name="ErrorTextBlock" />
             </StackPanel>
-            <Button Height="50"
-                    Width="150"
-                    x:Name="RecordButton"
-                    Content="Record"
-                    FontSize="28"
-                    Click="RecordButton_Click" />
-            <Button x:Name="PauseButton"
-                    Height="50"
-                    Width="150"
-                    Content="Pause"
-                    FontSize="28"
-                    Visibility="Hidden"
-                    Click="PauseButton_Click" />
-        </StackPanel>
+
+
+            <StackPanel Orientation="Horizontal">
+
+
+                        <StackPanel Orientation="Vertical">
+                            <Label Content="Input Volume" Margin="0,10"></Label>
+                            <Label Content="100%"></Label>
+                            <Slider Name="InputVolumeSlider" Orientation="Vertical"  Margin="10,0" Foreground="Blue" Maximum="1" TickPlacement="BottomRight" Height="150" Value="1" TickFrequency="0.1" ValueChanged="OnInputVolumeChanged"/>
+                            <Label Content="0%"></Label>
+                        </StackPanel>
+
+                        <StackPanel Orientation="Vertical" >
+                            <Label Content="Output Volume" Margin="0,10"></Label>
+                            <Label Content="100%"></Label>
+                            <Slider Name="OutputVolumeSlider" Orientation="Vertical"  Margin="10,0" Foreground="Blue" Maximum="1" TickPlacement="BottomRight" Height="150" Value="1" TickFrequency="0.1" ValueChanged="OnOutputVolumeChanged"/>
+                            <Label Content="0%"></Label>
+                        </StackPanel>
+
+
+                        <StackPanel Orientation="Vertical">
+                                <TextBlock FontSize="72"
+                                           Text="00:00:00"
+                                           HorizontalAlignment="Center"
+                                           x:Name="TimeStampTextBlock" 
+                                           Margin="10,0"/>
+                                <TextBlock FontSize="42"
+                                           Text="Idle"
+                                           HorizontalAlignment="Center"
+                                           x:Name="StatusTextBlock" />
+                                <TextBlock FontSize="12"
+                                           Text=""
+                                           Margin="10,0"
+                                           TextWrapping="Wrap"
+                                           HorizontalAlignment="Center"
+                                           x:Name="ErrorTextBlock" />
+                                <Button Height="50"
+                                        Width="150"
+                                        x:Name="RecordButton"
+                                        Content="Record"
+                                        FontSize="28"
+                                        Click="RecordButton_Click" />
+                                <Button x:Name="PauseButton"
+                                        Height="50"
+                                        Width="150"
+                                        Content="Pause"
+                                        FontSize="28"
+                                        Visibility="Hidden"
+                                        Click="PauseButton_Click" />
+                            </StackPanel>
+                    </StackPanel>
+            </StackPanel>
+
+           
         <TextBlock Margin="5"
                    TextWrapping="Wrap"
                    Grid.Row="1">

--- a/TestApp/MainWindow.xaml.cs
+++ b/TestApp/MainWindow.xaml.cs
@@ -243,7 +243,9 @@ namespace TestApp
                     IsOutputDeviceEnabled = IsAudioOutEnabled,
                     IsInputDeviceEnabled = IsAudioInEnabled,
                     AudioOutputDevice = audioOutputDevice,
-                    AudioInputDevice = audioInputDevice
+                    AudioInputDevice = audioInputDevice,
+                    InputVolume = (float)InputVolumeSlider.Value,
+                    OutputVolume = (float)OutputVolumeSlider.Value
                 },
                 VideoOptions = new VideoOptions
                 {
@@ -495,6 +497,23 @@ namespace TestApp
                     default:
                         break;
                 }
+            }
+        }
+
+        private void OnInputVolumeChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (_rec != null)
+            {
+                _rec.SetInputVolume((float)e.NewValue);
+            }
+            
+        }
+
+        private void OnOutputVolumeChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (_rec != null)
+            {
+                _rec.SetOutputVolume((float)e.NewValue);
             }
         }
     }


### PR DESCRIPTION
Hi, I love your work!. Very nice, powerful and simple to use library you've created.

I'd like to propose adding an audio volume mixer. With this implementation, volumes of input and output can be changed while recording.

MixAudio() method now accepts two extra parameters that specify volume if each of two two streams. The initial volumes can be set in AudioOptions or changed at recording time with Recorder.SetInputVolume() and Recorder.SetOutputVolume().

I've extended the UI in the TestApp with two volume sliders.
![mixer](https://user-images.githubusercontent.com/7221987/95012046-16eb4f80-0681-11eb-8ba0-f30d64f3953f.png)

I hope this is ok. I need this functionality in my project.

Thanks, and again, great work with this lib @sskodje 
Zee


