### PR TITLE
Support taking snapshots along with video recording

### DIFF
--- a/ScreenRecorderLib/Recorder.cpp
+++ b/ScreenRecorderLib/Recorder.cpp
@@ -24,6 +24,8 @@ void Recorder::SetOptions(RecorderOptions^ options) {
 			lRec->SetFixedFramerate(options->VideoOptions->IsFixedFramerate);
 			lRec->SetH264EncoderProfile((UINT32)options->VideoOptions->EncoderProfile);
 			lRec->SetVideoBitrateMode((UINT32)options->VideoOptions->BitrateMode);
+			lRec->SetTakeSnapthotsWithVideo(options->VideoOptions->SnapshotsWithVideo);
+			lRec->SetSnapthotsWithVideoInterval(options->VideoOptions->SnapshotsInterval);
 			switch (options->VideoOptions->SnapshotFormat)
 			{
 			case ImageFormat::BMP:

--- a/ScreenRecorderLib/Recorder.h
+++ b/ScreenRecorderLib/Recorder.h
@@ -144,6 +144,8 @@ namespace ScreenRecorderLib {
 			EncoderProfile = H264Profile::Baseline;
 			BitrateMode = BitrateControlMode::Quality;
 			SnapshotFormat = ImageFormat::PNG;
+			SnapshotsWithVideo = false;
+			SnapshotsInterval = 10;
 		}
 		property H264Profile EncoderProfile;
 		/// <summary>
@@ -170,6 +172,14 @@ namespace ScreenRecorderLib {
 		///Image format for snapshots. This is only used with Snapshot and Slideshow modes.
 		/// </summary>
 		property ImageFormat SnapshotFormat;
+		/// <summary>
+		///Whether to take snapshots in a video recording. This is only used with Video mode.
+		/// </summary>
+		property bool SnapshotsWithVideo;
+		/// <summary>
+		///Interval in second for taking snapshots in a video recording. This is only used with Video mode AND SnapshotsWithVideo enabled.
+		/// </summary>
+		property int SnapshotsInterval;
 	};
 	public ref class AudioOptions {
 	public:

--- a/TestApp/MainWindow.xaml
+++ b/TestApp/MainWindow.xaml
@@ -145,6 +145,10 @@
                                   x:Name="CheckBoxRecordToStream"
                                   IsChecked="{Binding ElementName=MainWin,Path=RecordToStream}"
                                   Margin="0" />
+                        <CheckBox Content="Take snapshots with Video"
+                                  x:Name="CheckBoxSnapshotsWithVideo"
+                                  IsChecked="{Binding ElementName=MainWin,Path=SnapshotsWithVideo}"
+                                  Margin="0" />
                         <StackPanel Orientation="Horizontal">
                             <Label Content="Mode"
                                    Width="85"
@@ -170,6 +174,20 @@
                                       ItemsSource="{Binding Source={StaticResource ImageFormatData}}"
                                       SelectedItem="{Binding ElementName=MainWin,Path=CurrentImageFormat}"
                                       VerticalAlignment="Top" />
+                        </StackPanel>
+
+                        <StackPanel Orientation="Horizontal"
+                                    x:Name="SnapshotsIntervalPanel"
+                                    Visibility="Collapsed">
+                            <Label Content="Snapshots interval"
+                                   Width="120"
+                                   VerticalAlignment="Center" />
+                            <TextBox x:Name="SnapshotsIntervalTextBox"
+                                     Width="30"
+                                     Text="{Binding ElementName=MainWin,Path=SnapshotsIntervalInSec}"
+                                     HorizontalAlignment="Left"
+                                     VerticalAlignment="Center" />
+                            <Label Content="second" />
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal"

--- a/TestApp/MainWindow.xaml.cs
+++ b/TestApp/MainWindow.xaml.cs
@@ -36,6 +36,7 @@ namespace TestApp
         public int VideoBitrate { get; set; } = 7000;
         public int VideoFramerate { get; set; } = 60;
         public int VideoQuality { get; set; } = 70;
+        public int SnapshotsIntervalInSec { get; set; } = 10;
         public bool IsAudioEnabled { get; set; } = true;
         public bool IsMousePointerEnabled { get; set; } = true;
         public bool IsFixedFramerate { get; set; } = false;
@@ -76,6 +77,30 @@ namespace TestApp
                     else
                     {
                         this.RecordingModeComboBox.IsEnabled = true;
+                    }
+                }
+            }
+        }
+
+        private bool _snapshotsWithVideo = false;
+        public bool SnapshotsWithVideo
+        {
+            get { return _snapshotsWithVideo; }
+            set
+            {
+                if (_snapshotsWithVideo != value)
+                {
+                    _snapshotsWithVideo = value;
+                    RaisePropertyChanged("SnapshotsWithVideo");
+                    if (value)
+                    {
+                        this.SnapshotImageFormatPanel.Visibility = Visibility.Visible;
+                        this.SnapshotsIntervalPanel.Visibility = Visibility.Visible;
+                    }
+                    else
+                    {
+                        this.SnapshotImageFormatPanel.Visibility = Visibility.Collapsed;
+                        this.SnapshotsIntervalPanel.Visibility = Visibility.Collapsed;
                     }
                 }
             }
@@ -255,7 +280,9 @@ namespace TestApp
                     Quality = this.VideoQuality,
                     IsFixedFramerate = this.IsFixedFramerate,
                     EncoderProfile = this.CurrentH264Profile,
-                    SnapshotFormat = CurrentImageFormat
+                    SnapshotFormat = CurrentImageFormat,
+                    SnapshotsWithVideo = this.SnapshotsWithVideo,
+                    SnapshotsInterval = this.SnapshotsIntervalInSec
                 },
                 DisplayOptions = new DisplayOptions(selectedDisplay.DisplayName, left, top, right, bottom),
                 MouseOptions = new MouseOptions
@@ -486,13 +513,15 @@ namespace TestApp
                     case RecorderMode.Video:
                         this.VideoBitrateModePanel.Visibility = Visibility.Visible;
                         this.VideoProfilePanel.Visibility = Visibility.Visible;
-                        this.SnapshotImageFormatPanel.Visibility = Visibility.Collapsed;
+                        this.SnapshotImageFormatPanel.Visibility = SnapshotsWithVideo ? Visibility.Visible : Visibility.Collapsed;
+                        this.SnapshotsIntervalPanel.Visibility = SnapshotsWithVideo ? Visibility.Visible : Visibility.Collapsed;
                         break;
                     case RecorderMode.Slideshow:
                     case RecorderMode.Snapshot:
                         this.VideoBitrateModePanel.Visibility = Visibility.Collapsed;
                         this.VideoProfilePanel.Visibility = Visibility.Collapsed;
                         this.SnapshotImageFormatPanel.Visibility = Visibility.Visible;
+                        this.SnapshotsIntervalPanel.Visibility = Visibility.Collapsed;
                         break;
                     default:
                         break;


### PR DESCRIPTION
Hello @sskodje !

I implemented the idea discussed in #92 - take snapshots of a screen while recording. The snapshot is from one of frames that the ongoing video is recording, so it won't hit the limitation of IDXGIOutput1::DuplicateOutput, and consumes less system resources than capturing snapshots in a separate process. 

This functionality would be useful, for example, when you want to check recorded contents before finishing up a video recording. When this option is enabled, it will create a folder under the folder of .mp4 file and snapshots will be saved in the folder.

You can specify interval of taking snapshots. If you want to capture a snapshot only at the beginning of a recording, you could specify a reasonable big value to the interval. 

![image](https://user-images.githubusercontent.com/16055659/96246774-14bfb400-0fe4-11eb-873c-4d64e64c0790.png)

I hope this is OK! I need this functionality in my project.

Thanks,
-Maki