### PR TITLE
Fix: Snapshots (with video) do not follow window resize

### DIFF
--- a/ScreenRecorderLibNative/screengrab.cpp
+++ b/ScreenRecorderLibNative/screengrab.cpp
@@ -190,6 +190,7 @@ HRESULT SaveWICTextureToFile(ID3D11DeviceContext* pContext,
 	ID3D11Resource* pSource,
 	REFGUID guidContainerFormat,
 	const wchar_t* fileName,
+	UINT widthCrop, UINT heightCrop,
 	const GUID* targetFormat,
 	std::function<void(IPropertyBag2*)> setCustomProps)
 {
@@ -201,6 +202,10 @@ HRESULT SaveWICTextureToFile(ID3D11DeviceContext* pContext,
 	HRESULT hr = CaptureTexture(pContext, pSource, desc, pStaging);
 	if (FAILED(hr))
 		return hr;
+
+	// In case the frame size is larger than the actual content, crop it for writing. 
+	UINT width = (widthCrop != 0 && widthCrop < desc.Width) ? widthCrop : desc.Width;
+	UINT height = (heightCrop != 0 && heightCrop < desc.Height) ? heightCrop : desc.Height;
 
 	// Determine source format's WIC equivalent
 	WICPixelFormatGUID pfGuid;
@@ -302,7 +307,7 @@ HRESULT SaveWICTextureToFile(ID3D11DeviceContext* pContext,
 	if (FAILED(hr))
 		return hr;
 
-	hr = frame->SetSize(desc.Width, desc.Height);
+	hr = frame->SetSize(width, height);
 	if (FAILED(hr))
 		return hr;
 
@@ -410,8 +415,8 @@ HRESULT SaveWICTextureToFile(ID3D11DeviceContext* pContext,
 	{
 		// Conversion required to write
 		CComPtr<IWICBitmap> source;
-		hr = pWIC->CreateBitmapFromMemory(desc.Width, desc.Height, pfGuid,
-			mapped.RowPitch, mapped.RowPitch * desc.Height,
+		hr = pWIC->CreateBitmapFromMemory(width, height, pfGuid,
+			mapped.RowPitch, mapped.RowPitch * height,
 			reinterpret_cast<BYTE*>(mapped.pData), &source);
 		if (FAILED(hr))
 		{
@@ -441,7 +446,7 @@ HRESULT SaveWICTextureToFile(ID3D11DeviceContext* pContext,
 			return hr;
 		}
 
-		WICRect rect = { 0, 0, static_cast<INT>(desc.Width), static_cast<INT>(desc.Height) };
+		WICRect rect = { 0, 0, static_cast<INT>(width), static_cast<INT>(height) };
 		hr = frame->WriteSource(FC, &rect);
 		if (FAILED(hr))
 		{
@@ -452,7 +457,7 @@ HRESULT SaveWICTextureToFile(ID3D11DeviceContext* pContext,
 	else
 	{
 		// No conversion required
-		hr = frame->WritePixels(desc.Height, mapped.RowPitch, mapped.RowPitch * desc.Height, reinterpret_cast<BYTE*>(mapped.pData));
+		hr = frame->WritePixels(height, mapped.RowPitch, mapped.RowPitch * height, reinterpret_cast<BYTE*>(mapped.pData));
 		if (FAILED(hr))
 			return hr;
 	}

--- a/ScreenRecorderLibNative/screengrab.h
+++ b/ScreenRecorderLibNative/screengrab.h
@@ -7,5 +7,7 @@ HRESULT __cdecl SaveWICTextureToFile(
     _In_ ID3D11Resource* pSource,
     _In_ REFGUID guidContainerFormat,
     _In_z_ const wchar_t* fileName,
+    _In_ UINT widthCrop = 0,
+    _In_ UINT heightCrop = 0,
     _In_opt_ const GUID* targetFormat = nullptr,
     _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);

--- a/Tests/FunctionTests.cs
+++ b/Tests/FunctionTests.cs
@@ -526,7 +526,7 @@ namespace ScreenRecorderLib
             try
             {
                 RecorderOptions options = new RecorderOptions();
-                options.VideoOptions = new VideoOptions { SnapshotsWithVideo = true, SnapshotsInterval = 1, SnapshotFormat = ImageFormat.JPEG };
+                options.VideoOptions = new VideoOptions { SnapshotsWithVideo = true, SnapshotsInterval = 2, SnapshotFormat = ImageFormat.JPEG };
                 using (var rec = Recorder.CreateRecorder(options))
                 {
                     List<string> snapshotCallbackList = new List<string>();
@@ -550,7 +550,7 @@ namespace ScreenRecorderLib
                         snapshotCallbackList.Add(args.SnapshotPath);
                     };
                     rec.Record(filePath);
-                    recordingResetEvent.WaitOne(5900);
+                    recordingResetEvent.WaitOne(11900); // 10 < x < 12 sec
                     rec.Stop();
                     finalizeResetEvent.WaitOne(5000);
 


### PR DESCRIPTION
Hi @sskodje !

Maybe very few people use this feature but, I found that snapshots taken with video do not follow window resize, since the image size was fixed to the one at the beginning of a recording.

Repro steps:

- Open TestApp
- Choose API: WindowsGraphicsCapture, check Take snapshots with Video, and choose a window to capture, then start recording
- Resize the captured window to **smaller** size
- Wait 10 or more sec and stop recording

Images generated after window resize would be messed up like this:
![2020-11-25 19-39-17](https://user-images.githubusercontent.com/16055659/100216761-04411880-2f56-11eb-9d39-b1dcf722de09.png)

I'm afraid my implementation is not optimal - maybe we'd better give `WriteFrameToImage` already cropped image, but I couldn't make it. `CropFrame` method threw exception for me. 

That said, this fix works for my purpose. If you need improvement, please let me know.