### PR TITLE
Support 20H1 features

### DIFF
--- a/ScreenRecorderLib/Recorder.cpp
+++ b/ScreenRecorderLib/Recorder.cpp
@@ -109,6 +109,11 @@ void Recorder::SetOutputVolume(float volume)
 	}
 }
 
+bool Recorder::ExcludeFromCapture(System::IntPtr hwnd, bool isExcluded)
+{
+	return internal_recorder::ExcludeFromCapture((HWND)hwnd.ToPointer(), isExcluded);
+}
+
 Dictionary<String^, String^>^ Recorder::GetSystemAudioDevices(AudioDeviceSource source)
 {
 	std::map<std::wstring, std::wstring> map;

--- a/ScreenRecorderLib/Recorder.h
+++ b/ScreenRecorderLib/Recorder.h
@@ -416,6 +416,7 @@ namespace ScreenRecorderLib {
 		void SetOptions(RecorderOptions^ options);
 		void SetInputVolume(float volume);
 		void SetOutputVolume(float volume);
+		static bool ExcludeFromCapture(System::IntPtr hwnd, bool isExcluded);
 		static Recorder^ CreateRecorder();
 		static Recorder^ CreateRecorder(RecorderOptions^ options);
 		static List<RecordableWindow^>^ GetWindows();

--- a/ScreenRecorderLib/ScreenRecorderLib.vcxproj
+++ b/ScreenRecorderLib/ScreenRecorderLib.vcxproj
@@ -23,7 +23,7 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>ScreenRecorderLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ScreenRecorderLibNative/ScreenRecorderLibNative.vcxproj
+++ b/ScreenRecorderLibNative/ScreenRecorderLibNative.vcxproj
@@ -119,7 +119,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{f2652fd6-eaf0-466d-b1cf-a7d19c1540ea}</ProjectGuid>
     <RootNamespace>ScreenRecorderLibNative</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -183,7 +183,6 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;SCREENRECORDERLIBNATIVE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -203,7 +202,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;SCREENRECORDERLIBNATIVE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -223,7 +221,6 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;SCREENRECORDERLIBNATIVE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -243,7 +240,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;SCREENRECORDERLIBNATIVE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>

--- a/ScreenRecorderLibNative/graphics_capture.h
+++ b/ScreenRecorderLibNative/graphics_capture.h
@@ -39,6 +39,7 @@ public:
 	void ClearFrameBuffer() { while (m_framePool.TryGetNextFrame() != nullptr) {}; }
 	winrt::Windows::Graphics::Capture::GraphicsCaptureItem CaptureItem() { return m_item; }
 	winrt::Windows::Graphics::Capture::Direct3D11CaptureFrame TryGetNextFrame() { return m_framePool.TryGetNextFrame(); }
+	void EnableCursorCapture(bool isEnabled) { m_session.IsCursorCaptureEnabled(isEnabled); }
 	void Close();
 
 private:

--- a/ScreenRecorderLibNative/internal_recorder.h
+++ b/ScreenRecorderLibNative/internal_recorder.h
@@ -140,6 +140,7 @@ public:
 	void SetOutputVolume(float volume) { m_OutputVolumeModifier = volume; }
 	void SetTakeSnapthotsWithVideo(bool isEnabled) { m_TakesSnapshotsWithVideo = isEnabled; }
 	void SetSnapthotsWithVideoInterval(UINT32 value) { m_SnapshotsWithVideoInterval = std::chrono::seconds(value); }
+	static bool ExcludeFromCapture(HWND hwnd, bool isExcluded);
 
 	[[deprecated]]
 	void SetDisplayOutput(UINT32 output) { m_DisplayOutput = output; }

--- a/TestApp/MainWindow.xaml
+++ b/TestApp/MainWindow.xaml
@@ -488,6 +488,10 @@
 
             <StackPanel Orientation="Vertical"
                         x:Name="ControlsPanel">
+                <CheckBox Content="Exclude this window from capture"
+                                  x:Name="CheckBoxExclude"
+                                  IsChecked="{Binding ElementName=MainWin,Path=IsExcludeWindowEnabled}"
+                                  Margin="0" />
                 <TextBlock FontSize="72"
                            Text="00:00:00"
                            HorizontalAlignment="Center"

--- a/TestApp/MainWindow.xaml.cs
+++ b/TestApp/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Threading;
 using Win32Interop.WinHandles;
@@ -84,6 +85,22 @@ namespace TestApp
             }
         }
 
+        private bool _isExcludeWindowEnabled = false;
+        public bool IsExcludeWindowEnabled
+        {
+            get { return _isExcludeWindowEnabled; }
+            set
+            {
+                if (_isExcludeWindowEnabled != value)
+                {
+                    _isExcludeWindowEnabled = value;
+                    RaisePropertyChanged("IsExcludeWindowEnabled");
+
+                    IntPtr hwnd = new WindowInteropHelper(this).Handle;
+                    Recorder.ExcludeFromCapture(hwnd, value);
+                }
+            }
+        }
         private bool _snapshotsWithVideo = false;
         public bool SnapshotsWithVideo
         {


### PR DESCRIPTION
Hi @sskodje !
This PR enables us to make use of two new features of Windows explained in "What’s next?" section of [this MSFT blog](https://blogs.windows.com/windowsdeveloper/2019/09/16/new-ways-to-do-screen-capture/):
- Hide mouse cursor in app window capture (i.e. capture by Windows.Graphics.Capture)
- Exclude window from capture

For the first one we just can specify whether to capture mouse cursor by `IsMousePointerEnabled` in app window capture mode, as we already support for display capture mode.
For the latter one I added a new option in TestApp to call a newly introduced static method. An app could call the method with any window handle any time, but apparently it's effective only for **top level window that belongs to the process**. [API spec](https://docs.microsoft.com/ja-jp/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity?redirectedfrom=MSDN)

![image](https://user-images.githubusercontent.com/16055659/101275047-04f36d80-37e6-11eb-858b-40622d93a85b.png)

In older Windows builds, setting these options will have no effect.
**Note**: These features require the latest Windows SDK (10.0.19041.0) to build, and to avoid build error I removed [the C++ conformance mode](https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-160) build option.

The _Exclude_ feature is very powerful in particular, which I'd love to use. Hope you like it!