### PR TITLE
Enable auto build

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,26 @@
+name: MSBuild
+
+on: [push, pull_request]
+
+env:
+  SOLUTION_NAME: ScreenRecorderLib
+  PROJECT_NAME: TestApp
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: [x64, x86]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: microsoft/setup-msbuild@v1
+    - run: nuget restore ${{ env.SOLUTION_NAME }}.sln
+    - run: msbuild /m '/p:Configuration=Release;Platform="${{ matrix.platform }}"' ${{ env.SOLUTION_NAME }}.sln
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.SOLUTION_NAME }}-${{ matrix.platform }}-${{ github.sha }}
+        path: ${{ env.PROJECT_NAME }}\bin\${{ matrix.platform }}\Release


### PR DESCRIPTION
Hi @sskodje !
Hoping to help everyone test updates on the repository more easily, I suggest automatic build leveraging GitHub Actions. 
Unless you disable Actions in the repository settings, every push and pull request will trigger builds for x64 and x86 build platforms. The result binaries of TestApp project can be downloaded until those are deleted (90 days AFAIK). 
I didn't configure to run unit test in the action because one of the tests (QualitySettingTest) failed on the runner.