### PR TITLE
Support resize output video/image

### DIFF
--- a/ScreenRecorderLib/Recorder.cpp
+++ b/ScreenRecorderLib/Recorder.cpp
@@ -24,6 +24,9 @@ void Recorder::SetOptions(RecorderOptions^ options) {
 			lRec->SetVideoBitrateMode((UINT32)options->VideoOptions->BitrateMode);
 			lRec->SetTakeSnapthotsWithVideo(options->VideoOptions->SnapshotsWithVideo);
 			lRec->SetSnapthotsWithVideoInterval(options->VideoOptions->SnapshotsInterval);
+			lRec->SetScaledFrameWidth(options->VideoOptions->ScaledFrameWidth);
+			lRec->SetScaledFrameHeight(options->VideoOptions->ScaledFrameHeight);
+			lRec->SetScaledFrameRatio(options->VideoOptions->ScaledFrameRatio);
 			switch (options->VideoOptions->SnapshotFormat)
 			{
 			case ImageFormat::BMP:

--- a/ScreenRecorderLib/Recorder.h
+++ b/ScreenRecorderLib/Recorder.h
@@ -157,6 +157,9 @@ namespace ScreenRecorderLib {
 			SnapshotFormat = ImageFormat::PNG;
 			SnapshotsWithVideo = false;
 			SnapshotsInterval = 10;
+			ScaledFrameWidth = 0;
+			ScaledFrameHeight = 0;
+			ScaledFrameRatio = 1.0;
 		}
 		property H264Profile EncoderProfile;
 		/// <summary>
@@ -191,6 +194,19 @@ namespace ScreenRecorderLib {
 		///Interval in second for taking snapshots in a video recording. This is only used with Video mode AND SnapshotsWithVideo enabled.
 		/// </summary>
 		property int SnapshotsInterval;
+		/// <summary>
+		///If non-zero, represents target frame width to resize.
+		/// </summary>
+		property int ScaledFrameWidth;
+		/// <summary>
+		///If non-zero, represents target frame height to resize.
+		/// </summary>
+		property int ScaledFrameHeight;
+		/// <summary>
+		///Specifies scaling ratio with which original frames are resized. 
+		///Will be ignored if non-zero values are specified both for ScaledFrameWidth and ScaledFrameHeight.
+		/// </summary>
+		property double ScaledFrameRatio;
 	};
 	public ref class AudioOptions {
 	public:

--- a/ScreenRecorderLibNative/Resizer.cpp
+++ b/ScreenRecorderLibNative/Resizer.cpp
@@ -1,0 +1,257 @@
+#include "Resizer.h"
+#include "screengrab.h"
+#include "utilities.h"
+#include <wincodec.h>
+#include <atlbase.h>
+
+using namespace DirectX;
+
+Resizer::Resizer() :
+	m_Device(nullptr),
+	m_DeviceContext(nullptr),
+	m_SamplerLinear(nullptr),
+	m_BlendState(nullptr),
+	m_VertexShader(nullptr),
+	m_PixelShader(nullptr),
+	m_InputLayout(nullptr)
+{
+}
+
+Resizer::~Resizer()
+{
+    CleanRefs();
+}
+
+HRESULT Resizer::Initialize(ID3D11DeviceContext* ImmediateContext, ID3D11Device* Device)
+{
+    m_Device = Device;
+    m_DeviceContext = ImmediateContext;
+
+    HRESULT hr;
+
+    // Create the sample state
+    D3D11_SAMPLER_DESC SampDesc;
+    RtlZeroMemory(&SampDesc, sizeof(SampDesc));
+    SampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+    SampDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+    SampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+    SampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+    SampDesc.ComparisonFunc = D3D11_COMPARISON_NEVER;
+    SampDesc.MinLOD = 0;
+    SampDesc.MaxLOD = D3D11_FLOAT32_MAX;
+    hr = m_Device->CreateSamplerState(&SampDesc, &m_SamplerLinear);
+    RETURN_ON_BAD_HR(hr);
+
+    // Create the blend state
+    D3D11_BLEND_DESC BlendStateDesc;
+    BlendStateDesc.AlphaToCoverageEnable = FALSE;
+    BlendStateDesc.IndependentBlendEnable = FALSE;
+    BlendStateDesc.RenderTarget[0].BlendEnable = TRUE;
+    BlendStateDesc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
+    BlendStateDesc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+    BlendStateDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+    BlendStateDesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
+    BlendStateDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
+    BlendStateDesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+    BlendStateDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+    hr = m_Device->CreateBlendState(&BlendStateDesc, &m_BlendState);
+    RETURN_ON_BAD_HR(hr);
+
+    // Initialize shaders
+    hr = InitShaders();
+    RETURN_ON_BAD_HR(hr);
+
+    return S_OK;
+}
+
+HRESULT Resizer::Resize(ID3D11Texture2D* orgTexture, ID3D11Texture2D** pResizedTexture, UINT targetWidth, UINT targetHeight, double viewPortRatio_width, double viewPortRatio_height)
+{
+    HRESULT hr;
+
+    // Create shader resource from texture of the original frame
+    D3D11_TEXTURE2D_DESC desktopDesc = {};
+    orgTexture->GetDesc(&desktopDesc);
+    D3D11_SHADER_RESOURCE_VIEW_DESC SDesc = {};
+    SDesc.Format = desktopDesc.Format;
+    SDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+    SDesc.Texture2D.MostDetailedMip = desktopDesc.MipLevels - 1;
+    SDesc.Texture2D.MipLevels = desktopDesc.MipLevels;
+    ID3D11ShaderResourceView* srcSRV;
+    hr = m_Device->CreateShaderResourceView(orgTexture, &SDesc, &srcSRV);
+    if (FAILED(hr))
+    {
+        _com_error err(hr);
+        ERROR(L"Failed to create shader resource from original frame's texture: %ls", err.ErrorMessage());
+        return hr;
+    }
+
+    // Create target texture
+    CComPtr<ID3D11Texture2D> pResizedFrame = nullptr;
+    D3D11_TEXTURE2D_DESC targetDesc;
+    InitializeDesc(targetWidth, targetHeight, &targetDesc);
+    hr = m_Device->CreateTexture2D(&targetDesc, nullptr, &pResizedFrame);
+    RETURN_ON_BAD_HR(hr);
+    *pResizedTexture = pResizedFrame;
+    (*pResizedTexture)->AddRef();
+
+    // Make new render target view
+    ID3D11RenderTargetView* RTV;
+    hr = m_Device->CreateRenderTargetView(pResizedFrame, nullptr, &RTV);
+    RETURN_ON_BAD_HR(hr);
+
+    m_DeviceContext->OMSetRenderTargets(1, &RTV, nullptr);
+
+    // Set view port
+    SetViewPort(targetWidth, targetHeight, viewPortRatio_width, viewPortRatio_height);
+
+    // Vertices for drawing whole texture
+    VERTEX Vertices[] =
+    {
+        {XMFLOAT3(-1.0f, -1.0f, 0), XMFLOAT2(0.0f, 1.0f)},
+        {XMFLOAT3(-1.0f, 1.0f, 0), XMFLOAT2(0.0f, 0.0f)},
+        {XMFLOAT3(1.0f, -1.0f, 0), XMFLOAT2(1.0f, 1.0f)},
+        {XMFLOAT3(1.0f, 1.0f, 0), XMFLOAT2(1.0f, 0.0f)},
+    };
+
+    // Set resources
+    UINT Stride = sizeof(VERTEX);
+    UINT Offset = 0;
+    FLOAT blendFactor[4] = { 0.f, 0.f, 0.f, 0.f };
+    m_DeviceContext->OMSetBlendState(nullptr, blendFactor, 0xffffffff);
+    m_DeviceContext->OMSetRenderTargets(1, &RTV, nullptr);
+    m_DeviceContext->VSSetShader(m_VertexShader, nullptr, 0);
+    m_DeviceContext->PSSetShader(m_PixelShader, nullptr, 0);
+    m_DeviceContext->PSSetShaderResources(0, 1, &srcSRV);
+    m_DeviceContext->PSSetSamplers(0, 1, &m_SamplerLinear);
+    m_DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);    // For 4 vertices
+
+    D3D11_BUFFER_DESC BufferDesc;
+    RtlZeroMemory(&BufferDesc, sizeof(BufferDesc));
+    BufferDesc.Usage = D3D11_USAGE_DEFAULT;
+    BufferDesc.ByteWidth = sizeof(VERTEX) * _countof(Vertices);
+    BufferDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+    BufferDesc.CPUAccessFlags = 0;
+    D3D11_SUBRESOURCE_DATA InitData;
+    RtlZeroMemory(&InitData, sizeof(InitData));
+    InitData.pSysMem = Vertices;
+
+    ID3D11Buffer* VertexBuffer = nullptr;
+
+    // Create vertex buffer
+    hr = m_Device->CreateBuffer(&BufferDesc, &InitData, &VertexBuffer);
+    if (FAILED(hr))
+    {
+        srcSRV->Release();
+        srcSRV = nullptr;
+        return S_FALSE;
+    }
+    m_DeviceContext->IASetVertexBuffers(0, 1, &VertexBuffer, &Stride, &Offset);
+
+    // Draw textured quad onto render target
+    m_DeviceContext->Draw(_countof(Vertices), 0);
+
+    // Clean up
+    VertexBuffer->Release();
+    VertexBuffer = nullptr;
+
+    srcSRV->Release();
+    srcSRV = nullptr;
+
+    RTV->Release();
+    RTV = nullptr;
+
+    return S_OK;
+}
+
+HRESULT Resizer::InitializeDesc(_In_ UINT width, _In_ UINT height, _Out_ D3D11_TEXTURE2D_DESC* pTargetDesc)
+{
+    // Create shared texture for the target view
+    RtlZeroMemory(pTargetDesc, sizeof(D3D11_TEXTURE2D_DESC));
+    pTargetDesc->Width = width;
+    pTargetDesc->Height = height;
+    pTargetDesc->MipLevels = 1;
+    pTargetDesc->ArraySize = 1;
+    pTargetDesc->Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    pTargetDesc->SampleDesc.Count = 1;
+    pTargetDesc->Usage = D3D11_USAGE_DEFAULT;
+    pTargetDesc->BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+    pTargetDesc->CPUAccessFlags = 0;
+    pTargetDesc->MiscFlags = 0;
+
+    return S_OK;
+}
+
+void Resizer::SetViewPort(UINT width, UINT height, double viewPortRatio_width, double viewPortRatio_height)
+{
+    D3D11_VIEWPORT VP;
+    VP.Width = static_cast<FLOAT>(width * viewPortRatio_width);
+    VP.Height = static_cast<FLOAT>(height * viewPortRatio_height);
+    VP.MinDepth = 0.0f;
+    VP.MaxDepth = 1.0f;
+    VP.TopLeftX = 0;
+    VP.TopLeftY = 0;
+    m_DeviceContext->RSSetViewports(1, &VP);
+}
+//
+// Initialize shaders for drawing to screen
+//
+HRESULT Resizer::InitShaders()
+{
+    HRESULT hr;
+
+    UINT Size = ARRAYSIZE(g_VS);
+    hr = m_Device->CreateVertexShader(g_VS, Size, nullptr, &m_VertexShader);
+    RETURN_ON_BAD_HR(hr);
+
+    D3D11_INPUT_ELEMENT_DESC Layout[] =
+    {
+        {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0}
+    };
+    UINT NumElements = ARRAYSIZE(Layout);
+    hr = m_Device->CreateInputLayout(Layout, NumElements, g_VS, Size, &m_InputLayout);
+    RETURN_ON_BAD_HR(hr);
+
+    m_DeviceContext->IASetInputLayout(m_InputLayout);
+
+    Size = ARRAYSIZE(g_PS);
+    hr = m_Device->CreatePixelShader(g_PS, Size, nullptr, &m_PixelShader);
+    RETURN_ON_BAD_HR(hr);
+
+    return S_OK;
+}
+//
+// Releases all references
+//
+void Resizer::CleanRefs()
+{
+    if (m_VertexShader)
+    {
+        m_VertexShader->Release();
+        m_VertexShader = nullptr;
+    }
+
+    if (m_PixelShader)
+    {
+        m_PixelShader->Release();
+        m_PixelShader = nullptr;
+    }
+
+    if (m_InputLayout)
+    {
+        m_InputLayout->Release();
+        m_InputLayout = nullptr;
+    }
+
+    if (m_SamplerLinear)
+    {
+        m_SamplerLinear->Release();
+        m_SamplerLinear = nullptr;
+    }
+
+    if (m_BlendState)
+    {
+        m_BlendState->Release();
+        m_BlendState = nullptr;
+    }
+}

--- a/ScreenRecorderLibNative/Resizer.h
+++ b/ScreenRecorderLibNative/Resizer.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <windows.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include <DirectXMath.h>
+
+#include "PixelShader.h"
+#include "VertexShader.h"
+
+class Resizer
+{
+public:
+    //
+    // A vertex with a position and texture coordinate
+    //
+    typedef struct _VERTEX
+    {
+        DirectX::XMFLOAT3 Pos;
+        DirectX::XMFLOAT2 TexCoord;
+    } VERTEX;
+
+	Resizer();
+	~Resizer();
+    HRESULT Initialize(ID3D11DeviceContext* ImmediateContext, ID3D11Device* Device);
+    HRESULT Resize(ID3D11Texture2D* orgTexture, ID3D11Texture2D** pResizedTexture, UINT targetWidth, UINT targetHeight, double viewPortRatio_width = 1.0, double viewPortRatio_height = 1.0);
+
+private:
+    void SetViewPort(UINT width, UINT height, double viewPortRatio_width, double viewPortRatio_height);
+    HRESULT InitShaders();
+    HRESULT InitializeDesc(_In_ UINT width, _In_ UINT height, _Out_ D3D11_TEXTURE2D_DESC* pTargetDesc);
+    void CleanRefs();
+
+    ID3D11Device* m_Device;
+    ID3D11DeviceContext* m_DeviceContext;
+    ID3D11SamplerState* m_SamplerLinear;
+    ID3D11BlendState* m_BlendState;
+    ID3D11VertexShader* m_VertexShader;
+    ID3D11PixelShader* m_PixelShader;
+    ID3D11InputLayout* m_InputLayout;
+};
+

--- a/ScreenRecorderLibNative/ScreenRecorderLibNative.vcxproj
+++ b/ScreenRecorderLibNative/ScreenRecorderLibNative.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Resizer.h" />
     <ClInclude Include="screengrab.h" />
     <ClInclude Include="audio_prefs.h" />
     <ClInclude Include="graphics_capture.h" />
@@ -36,6 +37,7 @@
     <ClInclude Include="WWMFResampler.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Resizer.cpp" />
     <ClCompile Include="screengrab.cpp" />
     <ClCompile Include="audio_prefs.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>

--- a/ScreenRecorderLibNative/ScreenRecorderLibNative.vcxproj.filters
+++ b/ScreenRecorderLibNative/ScreenRecorderLibNative.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClInclude Include="screengrab.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Resizer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="audio_prefs.cpp">
@@ -84,6 +87,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="screengrab.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Resizer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/ScreenRecorderLibNative/mouse_pointer.h
+++ b/ScreenRecorderLibNative/mouse_pointer.h
@@ -39,7 +39,7 @@ public:
 
 	HRESULT Initialize(ID3D11DeviceContext *ImmediateContext, ID3D11Device *Device);
 
-	HRESULT DrawMousePointer(_In_ PTR_INFO *PtrInfo, _In_ ID3D11DeviceContext *DeviceContext, _In_ ID3D11Device *Device, _Inout_ ID3D11Texture2D *bgTexture, DXGI_MODE_ROTATION rotation);
+	HRESULT DrawMousePointer(_In_ PTR_INFO *PtrInfo, _In_ ID3D11DeviceContext *DeviceContext, _In_ ID3D11Device *Device, _Inout_ ID3D11Texture2D* targetTexture, DXGI_MODE_ROTATION rotation, _In_ ID3D11Texture2D* desktopTexture = nullptr);
 	HRESULT DrawMouseClick(_In_ PTR_INFO *PtrInfo, _In_ ID3D11Texture2D *bgTexture, std::string colorStr, float radius, DXGI_MODE_ROTATION rotation);
 	HRESULT GetMouse(_Inout_ PTR_INFO *PtrInfo, _In_ DXGI_OUTDUPL_FRAME_INFO *FrameInfo, RECT screenRect, IDXGIOutputDuplication* DeskDupl);
 	HRESULT GetMouse(_Inout_ PTR_INFO *PtrInfo, int offsetX, int offsetY, RECT screenRect, bool getShapeBuffer);
@@ -63,7 +63,7 @@ private:
 	long ParseColorString(std::string color);
 	float GetCurrentDpi();
 	void GetPointerPosition(_In_ PTR_INFO *PtrInfo, DXGI_MODE_ROTATION rotation, int desktopWidth, int desktopHeight, _Out_ INT *PtrLeft, _Out_ INT *PtrTop);
-	HRESULT ProcessMonoMask(_In_ ID3D11Texture2D *bgTexture, _In_ ID3D11DeviceContext *DeviceContext, _In_ ID3D11Device *Device, DXGI_MODE_ROTATION rotation, bool IsMono, _Inout_ PTR_INFO *PtrInfo, _Out_ INT *PtrWidth, _Out_ INT *PtrHeight, _Out_ INT *PtrLeft, _Out_ INT *PtrTop, _Outptr_result_bytebuffer_(*PtrHeight * *PtrWidth * BPP) BYTE **InitBuffer, _Out_ D3D11_BOX *Box);
+	HRESULT ProcessMonoMask(_In_ ID3D11Texture2D* desktopTexture, _In_ ID3D11DeviceContext *DeviceContext, _In_ ID3D11Device *Device, DXGI_MODE_ROTATION rotation, bool IsMono, _Inout_ PTR_INFO *PtrInfo, _Out_ INT *PtrWidth, _Out_ INT *PtrHeight, _Out_ INT *PtrLeft, _Out_ INT *PtrTop, _Outptr_result_bytebuffer_(*PtrHeight * *PtrWidth * BPP) BYTE **InitBuffer, _Out_ D3D11_BOX *Box);
 	HRESULT InitShaders(ID3D11DeviceContext *DeviceContext, ID3D11Device *Device);
 	HRESULT InitMouseClickTexture(ID3D11DeviceContext *ImmediateContext, ID3D11Device *Device);
 	HRESULT ResizeShapeBuffer(PTR_INFO* PtrInfo, int bufferSize);

--- a/ScreenRecorderLibNative/utilities.h
+++ b/ScreenRecorderLibNative/utilities.h
@@ -88,3 +88,10 @@ inline INT64 HundredNanosToMillis(INT64 hundredNanos) {
 	return round((double)hundredNanos / 10 / 1000);
 }
 
+// Make odd number even (e.g. 2559 to be 2560).
+inline UINT32 MakeEven(UINT32 number) {
+	if (number % 2 != 0) {
+		++number;
+	}
+	return number;
+}

--- a/TestApp/MainWindow.xaml
+++ b/TestApp/MainWindow.xaml
@@ -107,30 +107,47 @@
                         <TextBox x:Name="RecordingAreaLeftTextBox"
                              VerticalContentAlignment="Center"
                              GotFocus="TextBox_GotFocus"
-                             MinWidth="
-                         30" />
+                             MinWidth="30" Height="25"/>
                         <Label Content="top" />
                         <TextBox x:Name="RecordingAreaTopTextBox"
                              VerticalContentAlignment="Center"
                              GotFocus="TextBox_GotFocus"
-                             MinWidth="30" />
+                             MinWidth="30" Height="25"/>
                         <Label Content="right" />
                         <TextBox x:Name="RecordingAreaRightTextBox"
                              VerticalContentAlignment="Center"
                              GotFocus="TextBox_GotFocus"
-                             MinWidth="
-                         30" />
+                             MinWidth="30" Height="25"/>
                         <Label Content="bottom" />
                         <TextBox x:Name="RecordingAreaBottomTextBox"
                              VerticalContentAlignment="Center"
                              GotFocus="TextBox_GotFocus"
-                             MinWidth="30" />
+                             MinWidth="30" Height="25"/>
                     </StackPanel>
                     <Button HorizontalAlignment="Right" Margin="0,2" MinWidth="90"
                             Content="Refresh targets"
                             Click="RefreshButton_Click"/>
                 </DockPanel>
-
+                <StackPanel Orientation="Horizontal">
+                    <Label Content="Scale to:   width"/>
+                    <TextBox x:Name="ScaledWidthTextBox"
+                             VerticalContentAlignment="Center"
+                             GotFocus="TextBox_GotFocus"
+                             TextChanged="ScaledWidthTextBox_TextChanged"
+                             MinWidth="30" Height="25"/>
+                    <Label Content="height"/>
+                    <TextBox x:Name="ScaledHeightTextBox"
+                             VerticalContentAlignment="Center"
+                             GotFocus="TextBox_GotFocus"
+                             TextChanged="ScaledHeightTextBox_TextChanged"
+                             MinWidth="30" Height="25"/>
+                    <Label Content="ratio" Margin="10,0,0,0"/>
+                    <TextBox x:Name="ScaledFrameRatioTextBox"
+                             VerticalContentAlignment="Center"
+                             GotFocus="TextBox_GotFocus"
+                             MinWidth="30" Height="25"/>
+                </StackPanel>
+                
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -489,33 +506,31 @@
             <StackPanel Orientation="Vertical"
                         x:Name="ControlsPanel">
                 <CheckBox Content="Exclude this window from capture"
-                                  x:Name="CheckBoxExclude"
-                                  IsChecked="{Binding ElementName=MainWin,Path=IsExcludeWindowEnabled}"
-                                  Margin="0" />
-                <TextBlock FontSize="72"
+                              x:Name="CheckBoxExclude"
+                              IsChecked="{Binding ElementName=MainWin,Path=IsExcludeWindowEnabled}"
+                              Margin="0"/>
+                <TextBlock FontSize="32"
                            Text="00:00:00"
                            HorizontalAlignment="Center"
-                           x:Name="TimeStampTextBlock"
-                           Margin="10,0" />
-                <TextBlock FontSize="42"
+                           x:Name="TimeStampTextBlock" />
+                <TextBlock FontSize="28"
                            Text="Idle"
                            HorizontalAlignment="Center"
                            x:Name="StatusTextBlock" />
                 <TextBlock FontSize="12"
                            Text=""
-                           Margin="10,0"
                            TextWrapping="Wrap"
                            MaxWidth="{Binding ElementName=ControlsPanel,Path=ActualWidth}"
                            HorizontalAlignment="Center"
                            x:Name="ErrorTextBlock" />
-                <Button Height="50"
+                <Button Height="40"
                         Width="150"
                         x:Name="RecordButton"
                         Content="Record"
                         FontSize="28"
                         Click="RecordButton_Click" />
                 <Button x:Name="PauseButton"
-                        Height="50"
+                        Height="40"
                         Width="150"
                         Content="Pause"
                         FontSize="28"

--- a/TestApp/MainWindow.xaml.cs
+++ b/TestApp/MainWindow.xaml.cs
@@ -261,6 +261,14 @@ namespace TestApp
             Int32.TryParse(this.RecordingAreaLeftTextBox.Text, out left);
             int top = 0;
             Int32.TryParse(this.RecordingAreaTopTextBox.Text, out top);
+            int scaledWidth = 0;
+            Int32.TryParse(this.ScaledWidthTextBox.Text, out scaledWidth);
+            int scaledHeight = 0;
+            Int32.TryParse(this.ScaledHeightTextBox.Text, out scaledHeight);
+            double scaledFrameRatio;
+            Double.TryParse(this.ScaledFrameRatioTextBox.Text, out scaledFrameRatio);
+            if (scaledFrameRatio == 0)
+                scaledFrameRatio = 1.0;
 
             Display selectedDisplay = (Display)this.ScreenComboBox.SelectedItem;
 
@@ -304,7 +312,10 @@ namespace TestApp
                     EncoderProfile = this.CurrentH264Profile,
                     SnapshotFormat = CurrentImageFormat,
                     SnapshotsWithVideo = this.SnapshotsWithVideo,
-                    SnapshotsInterval = this.SnapshotsIntervalInSec
+                    SnapshotsInterval = this.SnapshotsIntervalInSec,
+                    ScaledFrameWidth = scaledWidth,
+                    ScaledFrameHeight = scaledHeight,
+                    ScaledFrameRatio = scaledFrameRatio
                 },
                 DisplayOptions = new DisplayOptions
                 {
@@ -687,6 +698,23 @@ namespace TestApp
 
             AudioOutputsComboBox.SelectedIndex = 0;
             AudioInputsComboBox.SelectedIndex = 0;
+        }
+
+        private void ScaledWidthTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            ScaledFrameRatioTextBox.IsEnabled = !IsValidSizeInScaledWidthHeight();
+        }
+        private void ScaledHeightTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            ScaledFrameRatioTextBox.IsEnabled = !IsValidSizeInScaledWidthHeight();
+        }
+        private bool IsValidSizeInScaledWidthHeight()
+        {
+            int width = 0;
+            Int32.TryParse(this.ScaledWidthTextBox.Text, out width);
+            int height = 0;
+            Int32.TryParse(this.ScaledHeightTextBox.Text, out height);
+            return width != 0 && height != 0;
         }
     }
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -90,6 +90,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi @sskodje ! As discussed in #121, I added resize (scaling) support to master branch. 

You can now specify absolute width and height of resized video/image, or scaling ratio for keep-aspect-ratio resize (absolute size is prioritized when both options are specified). For example, if I specify 0.5 in the scaling ratio with a 4K display (3840x2160), it generates a full HD video (1920x1080) whose file size is about 1/2 to 1/3 of the original. Note that image quality might not be good if you reduce the resolution to below full HD.

I had to add some patchy code to support resize with all existing features (especially I struggled with mouse pointer drawing when desktop is cropped). We could improve them when we migrate to the new branch. 

![image](https://user-images.githubusercontent.com/16055659/116886881-99161380-ac64-11eb-9593-0b992fdd0a34.png)
