### PR TITLE
Update NuGet package

### DIFF
--- a/Nuget/ScreenRecorderLib.nuspec
+++ b/Nuget/ScreenRecorderLib.nuspec
@@ -18,9 +18,11 @@
   </metadata>
   <files>
     <file src="ScreenRecorderLib.targets" target="build\ScreenRecorderLib.targets" />
-    <file src="..\x64\Release\ScreenRecorderLib.dll" target="build\x64\ScreenRecorderLib.dll" />
-    <file src="..\x64\Release\ScreenRecorderLib.xml" target="build\x64\ScreenRecorderLib.xml" />
-    <file src="..\Release\ScreenRecorderLib.dll" target="build\x86\ScreenRecorderLib.dll" />
-    <file src="..\Release\ScreenRecorderLib.xml" target="build\x86\ScreenRecorderLib.xml" />
+    <file src="..\x64\Release\ScreenRecorderLib.dll" target="runtimes\win-x64\native\ScreenRecorderLib.dll" />
+    <file src="..\x64\Release\ScreenRecorderLib.xml" target="runtimes\win-x64\native\ScreenRecorderLib.xml" />
+    <file src="..\x64\Release\ScreenRecorderLib.pdb" target="runtimes\win-x64\native\ScreenRecorderLib.pdb" />
+    <file src="..\Release\ScreenRecorderLib.dll" target="runtimes\win-x86\native\ScreenRecorderLib.dll" />
+    <file src="..\Release\ScreenRecorderLib.xml" target="runtimes\win-x86\native\ScreenRecorderLib.xml" />
+    <file src="..\Release\ScreenRecorderLib.pdb" target="runtimes\win-x86\native\ScreenRecorderLib.pdb" />
   </files>
 </package>

--- a/Nuget/ScreenRecorderLib.targets
+++ b/Nuget/ScreenRecorderLib.targets
@@ -6,30 +6,4 @@
     <Error  Text="$(MSBuildThisFileName) does not work correctly on '$(Platform)' platform. You need to specify platform (x86, Win32 or x64)." />
   </Target>
 
-  <Target Name="InjectReference" BeforeTargets="ResolveAssemblyReferences">
-  <ItemGroup>
-    <Reference Include="ScreenRecorderLib" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)x86\ScreenRecorderLib.dll</HintPath>
-    </Reference>
-	<Reference Include="ScreenRecorderLib" Condition="'$(Platform)' == 'Win32'">
-      <HintPath>$(MSBuildThisFileDirectory)x86\ScreenRecorderLib.dll</HintPath>
-    </Reference>
-    <Reference Include="ScreenRecorderLib" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)x64\ScreenRecorderLib.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-    <ItemGroup Condition="'$(Language)' == 'C++'">
-      <Content Include="$(MSBuildThisFileDirectory)\$(Platform)\*.*">
-        <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
-      </Content>
-    </ItemGroup>
-  </Target>
-  <Target Name="CopyLinkedContentFiles" BeforeTargets="Build">
-    <Copy SourceFiles="%(Content.Identity)"
-			  DestinationFiles="%(Content.Link)"
-			  SkipUnchangedFiles='true'
-			  OverwriteReadOnlyFiles='true'
-			  Condition="'%(Content.Link)' != ''" />
-  </Target>
 </Project>


### PR DESCRIPTION
- Use `runtimes` folder (only compatible with `<PackageReference>`)
- Embed .pdb files in the package too  

Closes #158