### PR TITLE
Fix content files being copied into project 

### DIFF
--- a/Nuget/ScreenRecorderLib.targets
+++ b/Nuget/ScreenRecorderLib.targets
@@ -25,7 +25,7 @@
       </Content>
     </ItemGroup>
   </Target>
-  <Target Name="CopyLinkedContentFiles" BeforeTargets="Build">
+  <Target Name="CopyLinkedContentFiles" BeforeTargets="Build" Condition="'$(Language)' == 'C++'">
     <Copy SourceFiles="%(Content.Identity)"
 			  DestinationFiles="%(Content.Link)"
 			  SkipUnchangedFiles='true'


### PR DESCRIPTION
If I understand correctly the target was added for C++/Cli projects so I'm just adding a condition.

Closes #158  