### PR TITLE
Added GIF support and Fixed Slideshow mode crash

### DIFF
--- a/ScreenRecorderLib/Options.h
+++ b/ScreenRecorderLib/Options.h
@@ -31,7 +31,8 @@ namespace ScreenRecorderLib {
 		PNG,
 		JPEG,
 		TIFF,
-		BMP
+		BMP,
+		GIF
 	};
 
 	public enum class AudioChannels {

--- a/ScreenRecorderLib/Recorder.cpp
+++ b/ScreenRecorderLib/Recorder.cpp
@@ -63,6 +63,9 @@ void Recorder::SetOptions(RecorderOptions^ options) {
 				case ImageFormat::BMP:
 					snapshotOptions->SetSnapshotSaveFormat(GUID_ContainerFormatBmp);
 					break;
+				case ImageFormat::GIF:
+					snapshotOptions->SetSnapshotSaveFormat(GUID_ContainerFormatGif);
+					break;
 				case ImageFormat::JPEG:
 					snapshotOptions->SetSnapshotSaveFormat(GUID_ContainerFormatJpeg);
 					break;

--- a/ScreenRecorderLibNative/AudioManager.cpp
+++ b/ScreenRecorderLibNative/AudioManager.cpp
@@ -42,7 +42,7 @@ HRESULT AudioManager::StopCapture()
 HRESULT AudioManager::ConfigureAudioCapture()
 {
 	HRESULT hr = S_FALSE;
-	if (GetAudioOptions()->IsAudioEnabled() && GetAudioOptions()->IsOutputDeviceEnabled() && m_IsCaptureEnabled)
+	if (GetAudioOptions() && GetAudioOptions()->IsAudioEnabled() && GetAudioOptions()->IsOutputDeviceEnabled() && m_IsCaptureEnabled)
 	{
 		if (!m_LoopbackCaptureOutputDevice) {
 			m_LoopbackCaptureOutputDevice = make_unique<LoopbackCapture>(L"AudioOutputDevice");
@@ -62,7 +62,7 @@ HRESULT AudioManager::ConfigureAudioCapture()
 		}
 	}
 
-	if (GetAudioOptions()->IsAudioEnabled() && GetAudioOptions()->IsInputDeviceEnabled() && m_IsCaptureEnabled)
+	if (GetAudioOptions() && GetAudioOptions()->IsAudioEnabled() && GetAudioOptions()->IsInputDeviceEnabled() && m_IsCaptureEnabled)
 	{
 		if (!m_LoopbackCaptureInputDevice) {
 			m_LoopbackCaptureInputDevice = make_unique<LoopbackCapture>(L"AudioInputDevice");

--- a/ScreenRecorderLibNative/CommonTypes.h
+++ b/ScreenRecorderLibNative/CommonTypes.h
@@ -551,6 +551,9 @@ public:
 		else if (m_ImageEncoderFormat == GUID_ContainerFormatTiff) {
 			return L".tiff";
 		}
+		else if (m_ImageEncoderFormat == GUID_ContainerFormatGif) {
+			return L".gif";
+		}
 		else {
 			return L".jpg";
 		}

--- a/ScreenRecorderLibNative/OutputManager.cpp
+++ b/ScreenRecorderLibNative/OutputManager.cpp
@@ -180,6 +180,14 @@ HRESULT OutputManager::FinalizeRecording()
 	return finalizeResult;
 }
 
+wstring uint64_to_string(uint64_t value, int prefixDigits = 0) {
+	wstring result = to_wstring(value);
+	while (result.length() < prefixDigits) {
+		result = L'0' + result;
+	}
+	return result;
+}
+
 HRESULT OutputManager::RenderFrame(_In_ FrameWriteModel &model) {
 	HRESULT hr(S_OK);
 	EnterCriticalSection(&m_CriticalSection);
@@ -228,7 +236,7 @@ HRESULT OutputManager::RenderFrame(_In_ FrameWriteModel &model) {
 		LOG_TRACE(L"Wrote %s with duration %.2f ms", frameInfoStr, HundredNanosToMillisDouble(model.Duration));
 	}
 	else if (recorderMode == RecorderModeInternal::Slideshow) {
-		wstring	path = m_OutputFolder + L"\\" + to_wstring(m_RenderedFrameCount) + GetSnapshotOptions()->GetImageExtension();
+		wstring	path = m_OutputFolder + L"\\" + uint64_to_string(m_RenderedFrameCount, 6) + GetSnapshotOptions()->GetImageExtension();
 		hr = WriteFrameToImage(model.Frame, path);
 		INT64 startposMs = HundredNanosToMillis(model.StartPos);
 		INT64 durationMs = HundredNanosToMillis(model.Duration);


### PR DESCRIPTION
1. Added GIF support for SnapshotFormat
1. Updated frame naming scheme in Slideshow to use the 6-digit format
This will be helpful to create GIF from frames. Tools like gifsicle will be able to frames in ascending order for the conversion
1. Fixed crash in SlideShow mode when it tries to get AudioOptions on the  null object