### PR TITLE
Link to the latest VC++ redist in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ScreenRecorderLib
-A .NET library for screen recording in Windows, using native Microsoft Media Foundation for realtime encoding to h264 video or PNG images. This library requires Windows 8 or higher to function, as well as [Visual C++ Redistributable x64](https://aka.ms/vs/16/release/vc_redist.x64.exe) or [Visual C++ Redistributable x86](https://aka.ms/vs/16/release/vc_redist.x86.exe) installed, depending on platform compiled for. This library also requires Media Foundation to work, which have to be installed from Server Manager if run on Windows Server, or from the respective "Media Feature Pack" if run on a Windows N or KN version.
+A .NET library for screen recording in Windows, using native Microsoft Media Foundation for realtime encoding to h264 video or PNG images. This library requires Windows 8 or higher to function, as well as Visual C++ Redistributable [x64](https://aka.ms/vs/17/release/vc_redist.x64.exe) or [x86](https://aka.ms/vs/17/release/vc_redist.x86.exe) installed, depending on platform compiled for. This library also requires Media Foundation to work, which have to be installed from Server Manager if run on Windows Server, or from the respective "Media Feature Pack" if run on a Windows N or KN version.
 
 Available on [NuGet](https://www.nuget.org/packages/ScreenRecorderLib/).
 


### PR DESCRIPTION
Hi @sskodje ,
Since the library is now built by the Visual Studio 2022 toolset ([related commit](https://github.com/sskodje/ScreenRecorderLib/commit/8e84e188e120de1f5f0d3744007938e19846c991)), it is advised that the latest VC++ Redistributable is installed to run this program.
This PR just updates the links in README to the latest ones according to [the Microsoft doc](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170), although the program looks still working with the old redist. 